### PR TITLE
Add layout, splitting, MDC, and thread name support to Logback appender

### DIFF
--- a/src/com/scalyr/logback/ScalyrAppender.java
+++ b/src/com/scalyr/logback/ScalyrAppender.java
@@ -1,35 +1,98 @@
 package com.scalyr.logback;
 
 import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.PatternLayout;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import com.scalyr.api.logs.EventAttributes;
 import com.scalyr.api.logs.Events;
 
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
 /**
- * Created by steve on 4/8/14.
+ * Logback appender that sends log messages to the Scalyr API.
  */
 public class ScalyrAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+    /**
+     * Scalyr's log message length limit
+     */
+    private static final int MAX_LENGTH = 3500;
+
+    private String continuationPrefix = "<CONT> ";
     private String apiKey = "";
     private String serverHost = "";
     private Integer maxBufferRam;
+    private Layout<ILoggingEvent> layout;
 
-    @Override protected void append(ILoggingEvent event) {
-        int level = event.getLevel().toInt();
-        String message = event.getFormattedMessage();
+    /**
+     * Splits a log message up into chunks, attempting to split on line boundaries if possible.
+     * Chunks after the first one are prefixed with the continuation prefix ("<CONT> " by default) to
+     * make it easy to reconstruct the original message.
+     */
+    private List<String> toChunks(String message) {
+        String remainder;
 
-        if (level >= Level.ERROR_INT) {
-            Events.error(new EventAttributes("message", "E " + message));
-        } else if (level >= Level.WARN_INT) {
-            Events.warning(new EventAttributes("message", "W " + message));
-        } else if (level >= Level.INFO_INT) {
-            Events.info(new EventAttributes("message", "I " + message));
-        } else if (level >= Level.DEBUG_INT) {
-            Events.fine(new EventAttributes("message", "J " + message));
-        } else if (level >= Level.TRACE_INT) {
-            Events.finer(new EventAttributes("message", "K " + message));
+        if (message.startsWith(continuationPrefix) || message.startsWith("\\")) {
+            // Disambiguate continuation lines
+            remainder = "\\" + message;
         } else {
-            Events.finest(new EventAttributes("message", "L " + message));
+            remainder = message;
+        }
+
+        List<String> chunks = new LinkedList<>();
+
+        while (remainder.length() > MAX_LENGTH) {
+            int splitPos = remainder.lastIndexOf('\n', MAX_LENGTH);
+            if (splitPos >= 0) {
+                chunks.add(remainder.substring(0, splitPos));
+                remainder = continuationPrefix + remainder.substring(splitPos + 1);
+            } else {
+                chunks.add(remainder.substring(0, MAX_LENGTH));
+                remainder = continuationPrefix + remainder.substring(MAX_LENGTH);
+            }
+        }
+
+        chunks.add(remainder);
+        return chunks;
+    }
+
+    @Override
+    protected void append(ILoggingEvent event) {
+        int level = event.getLevel().toInt();
+        Map<String, String> properties = event.getMDCPropertyMap();
+
+        String message = layout.doLayout(event);
+
+        // Scalyr doesn't currently allow the thread name to be queried, so add it as an attribute.
+        EventAttributes extraAttributes = new EventAttributes("threadName", event.getThreadName());
+
+        // If there are MDC properties (authentication principal, etc.), add them as attributes too.
+        if (properties != null) {
+            for (Map.Entry<String, String> propertyEntry : properties.entrySet()) {
+                extraAttributes.put(propertyEntry.getKey(), propertyEntry.getValue());
+            }
+        }
+
+        for (String chunk : toChunks(message)) {
+            EventAttributes eventAttributes = new EventAttributes("message", chunk);
+            eventAttributes.addAll(extraAttributes);
+
+            if (level >= Level.ERROR_INT) {
+                Events.error(eventAttributes);
+            } else if (level >= Level.WARN_INT) {
+                Events.warning(eventAttributes);
+            } else if (level >= Level.INFO_INT) {
+                Events.info(eventAttributes);
+            } else if (level >= Level.DEBUG_INT) {
+                Events.fine(eventAttributes);
+            } else if (level >= Level.TRACE_INT) {
+                Events.finer(eventAttributes);
+            } else {
+                Events.finest(eventAttributes);
+            }
         }
     }
 
@@ -66,8 +129,40 @@ public class ScalyrAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         }
     }
 
+    public Layout<ILoggingEvent> getLayout() {
+        return layout;
+    }
+
+    /**
+     * Sets the Logback layout to use for this appender. The default is a simple layout consisting of
+     * the first character of the level name (E, W, I, D, T for error, warning, info, debug, and
+     * trace, respectively) followed by the message.
+     */
+    public void setLayout(Layout<ILoggingEvent> layout) {
+        this.layout = layout;
+    }
+
+    public String getContinuationPrefix() {
+        return continuationPrefix;
+    }
+
+    /**
+     * Sets the prefix to be placed at the front of any log message that is a continuation of the
+     * previous ones. This happens when a log message is split into multiple pieces to fit within
+     * Scalyr's log message length limit. The default is "<CONT> ".
+     */
+    public void setContinuationPrefix(String continuationPrefix) {
+        this.continuationPrefix = continuationPrefix;
+    }
+
     @Override
     public void start() {
+        if (layout == null) {
+            // Use a simple default layout.
+            layout = new PatternLayout();
+            ((PatternLayout) layout).setPattern("%.-1level %msg");
+        }
+
         final EventAttributes serverAttributes = new EventAttributes();
         if (getServerHost().length() > 0)
             serverAttributes.put("serverHost", getServerHost());


### PR DESCRIPTION
Custom layouts may be specified using Logback "Layout" objects.

Long messages are split into pieces with a configurable prefix on the
second through Nth pieces, to avoid truncation due to the log message
length limit. If possible, the splitting is done at newline boundaries
so as not to chop lines in half in stack traces or other multi-line
messages.

MDC properties and thread names are automatically included as
attributes on log messages.