### PR TITLE
Added logback.xml sample

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,13 +56,13 @@ For log4j, you'll need:
 
 ##### Logback
 
-In your logback configuration file, add a com.scalyr.logback.ScalyrAppender. 
-See sample [logback.groovy](https://github.com/scalyr/scalyr-logback/blob/master/samples/logback.groovy)
+In your logback configuration file, add a `com.scalyr.logback.ScalyrAppender`. 
+See samples [logback.groovy](samples/logback.groovy) and [logback.xml](samples/logback.xml)
 
 ##### Log4J
 
 In your log4J configuration file, add a com.scalyr.log4j.ScalyrAppender.
-See sample [log4j.properties](https://github.com/scalyr/scalyr-logback/blob/master/samples/log4j.properties)
+See sample [log4j.properties](samples/log4j.properties)
 
 ### Parsing Rules
 
@@ -72,4 +72,4 @@ send a sample of your log data to the Scalyr staff, and we'll respond the same d
 
 ### Examples
 
-See [src/test/java/com/scalyr/logback/test/Test.java](https://github.com/scalyr/scalyr-logback/blob/master/src/test/java/com/scalyr/logback/test/Test.java) for usage examples.
+See [src/test/java/com/scalyr/logback/test/Test.java](src/test/java/com/scalyr/logback/test/Test.java) for usage examples.

--- a/samples/logback.xml
+++ b/samples/logback.xml
@@ -1,0 +1,18 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+
+        <encoder>
+            <pattern>%-4relative [%thread] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="SCALYR" class="com.scalyr.logback.ScalyrAppender">
+        <apiKey>YOUR_API_KEY_HERE</apiKey>
+    </appender>
+
+    <root level="warn">
+        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="SCALYR"/>
+    </root>
+</configuration


### PR DESCRIPTION
I've added a sample on how to configure the appender using logback's XML format instead of the groovy. I've also changed the links in the readme to be relative to the repository.