### PR TITLE
Made `logfile` and `parser` customizable

### DIFF
--- a/samples/log4j.properties
+++ b/samples/log4j.properties
@@ -1,3 +1,5 @@
 log4j.rootLogger=DEBUG, scalyr
 log4j.appender.scalyr=com.scalyr.log4j.ScalyrAppender
 log4j.appender.scalyr.apiKey=YOUR_API_KEY_HERE
+log4j.appender.scalyr.logfile=myapp
+log4j.appender.scalyr.parser=logback

--- a/samples/logback.groovy
+++ b/samples/logback.groovy
@@ -9,5 +9,7 @@ appender("CONSOLE", ConsoleAppender) {
 }
 appender("SCALYR", ScalyrAppender) {
 	apiKey = "YOUR_API_KEY_HERE"
+    logfile = "myapp"
+    parser = "logback"
 }
 root(WARN, ["CONSOLE", "SCALYR"])

--- a/samples/logback.xml
+++ b/samples/logback.xml
@@ -9,6 +9,8 @@
 
     <appender name="SCALYR" class="com.scalyr.logback.ScalyrAppender">
         <apiKey>YOUR_API_KEY_HERE</apiKey>
+        <logfile>myapp</logfile>
+        <parser>logback</parser>
     </appender>
 
     <root level="warn">

--- a/src/main/java/com/scalyr/log4j/ScalyrAppender.java
+++ b/src/main/java/com/scalyr/log4j/ScalyrAppender.java
@@ -9,6 +9,8 @@ import org.apache.log4j.spi.LoggingEvent;
 public class ScalyrAppender extends AppenderSkeleton {
     private String apiKey;
     private String serverHost = "";
+    private String logfile = "log4j";
+    private String parser = "log4j";
     private Integer maxBufferRam;
 
     public String getServerHost() {
@@ -18,6 +20,23 @@ public class ScalyrAppender extends AppenderSkeleton {
     public void setServerHost(String serverHost) {
         this.serverHost = serverHost;
     }
+
+    public String getLogfile() {
+        return logfile;
+    }
+
+    public void setLogfile(String logfile) {
+        this.logfile = logfile;
+    }
+
+    public String getParser() {
+        return parser;
+    }
+
+    public void setParser(String parser) {
+        this.parser = parser;
+    }
+
 
     @Override
     protected void append(LoggingEvent event) {
@@ -39,12 +58,12 @@ public class ScalyrAppender extends AppenderSkeleton {
         }
     }
     public void activateOptions() {
-        if(this.apiKey != null && !"".equals(this.apiKey.trim())) {
+        if (this.apiKey != null && !"".equals(this.apiKey.trim())) {
             final EventAttributes serverAttributes = new EventAttributes();
             if (getServerHost().length() > 0)
                 serverAttributes.put("serverHost", getServerHost());
-            serverAttributes.put("logfile", "log4j");
-            serverAttributes.put("parser", "log4j");
+            serverAttributes.put("logfile", getLogfile());
+            serverAttributes.put("parser", getParser());
 
             // default to 4MB if not set.
             int maxBufferRam = (this.maxBufferRam != null) ? this.maxBufferRam : 4194304;
@@ -67,9 +86,9 @@ public class ScalyrAppender extends AppenderSkeleton {
     }
 
     public void setMaxBufferRam(String maxBufferRam) {
-        if(maxBufferRam != null && !"".equals(maxBufferRam)) {
+        if (maxBufferRam != null && !"".equals(maxBufferRam)) {
             maxBufferRam = maxBufferRam.toLowerCase().trim();
-            if(maxBufferRam.contains("m")) {
+            if (maxBufferRam.contains("m")) {
                 this.maxBufferRam = Integer.valueOf(maxBufferRam.substring(0, maxBufferRam.indexOf("m"))) * 1048576;
             } else if (maxBufferRam.contains("k")) {
                 this.maxBufferRam = Integer.valueOf(maxBufferRam.substring(0, maxBufferRam.indexOf("k"))) * 1024;
@@ -81,7 +100,7 @@ public class ScalyrAppender extends AppenderSkeleton {
 
     @Override
     public void close() {
-        if(this.closed) {
+        if (this.closed) {
             return;
         }
         Events.flush();

--- a/src/main/java/com/scalyr/logback/ScalyrAppender.java
+++ b/src/main/java/com/scalyr/logback/ScalyrAppender.java
@@ -13,6 +13,8 @@ public class ScalyrAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     private String apiKey = "";
     private String serverHost = "";
     private Integer maxBufferRam;
+    private String logfile = "logback";
+    private String parser = "logback";
 
     @Override protected void append(ILoggingEvent event) {
         int level = event.getLevel().toInt();
@@ -66,13 +68,29 @@ public class ScalyrAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
         }
     }
 
+    public void setLogfile(String logfile) {
+        this.logfile = logfile;
+    }
+
+    public String getLogfile() {
+        return logfile;
+    }
+
+    public String getParser() {
+        return parser;
+    }
+
+    public void setParser(String parser) {
+        this.parser = parser;
+    }
+
     @Override
     public void start() {
         final EventAttributes serverAttributes = new EventAttributes();
         if (getServerHost().length() > 0)
             serverAttributes.put("serverHost", getServerHost());
-        serverAttributes.put("logfile", "logback");
-        serverAttributes.put("parser", "logback");
+        serverAttributes.put("logfile", getLogfile());
+        serverAttributes.put("parser", getParser());
 
         if(this.apiKey != null && !"".equals(this.apiKey.trim())) {
             // default to 4MB if not set.


### PR DESCRIPTION
This will make the appenders a lot more flexible. Two jvm applications on the same host can now be in different log files and different log layouts can use different parsers