### PR TITLE
CT-413 Logback Appender produces empty messages

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Add the following dependency to your project's pom.xml (check [Maven Central](ht
         <dependency>
             <groupId>com.scalyr</groupId>
             <artifactId>logback-log4j-appenders</artifactId>
-            <version>6.0.7</version>
+            <version>6.0.8</version>
         </dependency>
 
 **NOTE:** You'll also need the logback or log4j dependencies in your project's pom.xml as well (depending on which one you're using).
@@ -49,7 +49,7 @@ For log4j, you'll need:
 ##### Downloading JARs directly
 
 * Download the Java client library from [Maven Central](https://oss.sonatype.org/content/groups/public/com/scalyr/scalyr-client/6.0.15/scalyr-client-6.0.15.jar) and add it to your project.
-* Download the Appender library from [Maven Central](https://oss.sonatype.org/content/groups/public/com/scalyr/logback-log4j-appenders/6.0.7/logback-log4j-appenders-6.0.7.jar) and add it to your project.
+* Download the Appender library from [Maven Central](https://oss.sonatype.org/content/groups/public/com/scalyr/logback-log4j-appenders/6.0.8/logback-log4j-appenders-6.0.8.jar) and add it to your project.
 * Make sure you also have either logback or log4j jars in your project, as described in the section above.
 
 ### Configuration

--- a/src/main/java/com/scalyr/logback/ScalyrAppender.java
+++ b/src/main/java/com/scalyr/logback/ScalyrAppender.java
@@ -120,6 +120,8 @@ public class ScalyrAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
      * consists of the first character of the level name (E, W, I, D, T for error,
      * warning, info, debug, and trace, respectively) followed by the message.
      *
+     * The Layout should have the logger context set and be started.
+     *
      * @param layout the Layout to use
      */
     public void setLayout(Layout<ILoggingEvent> layout) { this.layout = layout; }
@@ -130,6 +132,8 @@ public class ScalyrAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             //default layout
             layout = new PatternLayout();
             ((PatternLayout) layout).setPattern("%.-1level %msg");
+            layout.setContext(context);
+            layout.start();
         }
 
         final EventAttributes serverAttributes = new EventAttributes();


### PR DESCRIPTION
The empty message was caused by the `PatternLayout` not having the logger context set and `start` called.

`PatternLayout.doLayout` returns `null` for the message if not `isStarted`: https://github.com/qos-ch/logback/blob/master/logback-access/src/main/java/ch/qos/logback/access/PatternLayout.java#L197-L199

`PatternLayout` documentation: http://logback.qos.ch/manual/layouts.html#ClassicPatternLayout

Verified that messages are sent correctly to Scalyr after this change with the default encoder and also the `net.logstash.logback.encoder.LogstashEncoder`.