### PR TITLE
fix: log4j appender throwing null pointer exception

### DIFF
--- a/src/main/java/com/scalyr/log4j/ScalyrAppender.java
+++ b/src/main/java/com/scalyr/log4j/ScalyrAppender.java
@@ -146,6 +146,6 @@ public class ScalyrAppender extends AppenderSkeleton {
 
     @Override
     public boolean requiresLayout() {
-        return false;
+        return true;
     }
 }


### PR DESCRIPTION
In the current implementation of the [log4j ScalyrAppender](https://github.com/scalyr/scalyr-logback/blob/master/src/main/java/com/scalyr/log4j/ScalyrAppender.java#L88), the `getLayout()` method will always return `null` because the layout is not being read. This occurs because the `requiresLayout()` method is set to return `false` in [ScalyrAppender](https://github.com/scalyr/scalyr-logback/blob/master/src/main/java/com/scalyr/log4j/ScalyrAppender.java#L147-L150). As a result, even if a layout is configured for this appender in the logger configuration, it will not be utilized. To fix this issue, the `requiresLayout()` method should return `true`, allowing the layout to be read and applied properly.

For reference, see the [Appender class in Apache Log4j](https://github.com/apache/logging-log4j2/blob/47d861808ad8466d15a8b41fb4c5236d438c782e/log4j-1.2-api/src/main/java/org/apache/log4j/Appender.java#L120-L138) where `requiresLayout()` is used to determine if a layout is required.